### PR TITLE
Fix GitHub Actions workflow: Update docs directory path

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -27,7 +27,7 @@ jobs:
         pip install mkdocs mkdocs-material mkdocs-redirects mkdocs-git-revision-date-localized-plugin
 
     - name: Build documentation
-      working-directory: docs/comfydock-docs
+      working-directory: docs/comfygit-docs
       run: |
         mkdocs build --site-dir ../../build-output
         echo "✓ Documentation built successfully"
@@ -90,7 +90,7 @@ jobs:
         echo "✅ ComfyGit Documentation Deployed"
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
         echo "📍 Live URL: https://docs.comfyhub.org/comfygit/"
-        echo "📦 Source: docs/comfydock-docs/"
+        echo "📦 Source: docs/comfygit-docs/"
         echo "🎯 Target: comfyhub-org.github.io/comfygit/"
         echo "📝 Commit: ${{ github.sha }}"
         echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
The publish-docs workflow was still referencing the old directory name docs/comfydock-docs which was renamed to docs/comfygit-docs.

Changes:
- Updated working-directory from docs/comfydock-docs to docs/comfygit-docs
- Updated deployment summary to reference correct source directory

This fixes the workflow failure where the build step couldn't find the documentation directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)