### PR TITLE
Release ComfyGit 0.4.2

### DIFF
--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "comfygit"
-version = "0.4.1"
+version = "0.4.2"
 description = "ComfyGit - Git-based environment management for ComfyUI"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "comfygit-core==0.4.1",
+    "comfygit-core==0.4.2",
     "aiohttp>=3.13.4",
     "argcomplete>=3.5.0",
     "requests>=2.33.0",

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfygit-core"
-version = "0.4.1"
+version = "0.4.2"
 description = "ComfyGit Core - Git-based ComfyUI environment manager"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/core/src/comfygit_core/core/environment.py
+++ b/packages/core/src/comfygit_core/core/environment.py
@@ -456,10 +456,11 @@ class Environment:
         # Check if already tracked
         nodes = self.pyproject.nodes.get_existing()
         if MANAGER_NODE_ID in nodes and not was_migration:
-            # Standard update flow - update_node always updates to latest
+            # Standard update flow, optionally pinned to a caller-selected version.
             result = self.node_manager.update_node(
                 MANAGER_NODE_ID,
                 confirmation_strategy=confirmation_strategy,
+                target_version=None if version == "latest" else version,
             )
 
             # Cleanup legacy dependency group if present

--- a/packages/core/src/comfygit_core/managers/node_manager.py
+++ b/packages/core/src/comfygit_core/managers/node_manager.py
@@ -149,24 +149,12 @@ class NodeManager:
 
         return candidate
 
-    def _install_node_from_info(self, node_info: NodeInfo, no_test: bool = False) -> NodeInfo:
-        """Install a node given a pre-fetched NodeInfo object.
-
-        This bypasses the lookup/cache layer and directly installs the node
-        using the provided node info. Useful for update operations where we've
-        already fetched fresh data from the API.
-
-        Args:
-            node_info: Pre-fetched node information from API
-            no_test: Skip dependency resolution testing
-
-        Returns:
-            NodeInfo of the installed node
-
-        Raises:
-            CDEnvironmentError: If installation fails
-            CDNodeConflictError: If dependency conflicts detected
-        """
+    def _prepare_node_installation(
+        self,
+        node_info: NodeInfo,
+        no_test: bool = False,
+    ) -> tuple[Path, NodePackage]:
+        """Download, scan, and validate a node before mutating the environment."""
         # Download to cache
         cache_path = self.node_lookup.download_to_cache(node_info)
         if not cache_path:
@@ -186,6 +174,28 @@ class NodeManager:
                 # Pass first requirement as package_spec for conflict analysis
                 pkg_spec = node_package.requirements[0] if node_package.requirements else None
                 self._raise_dependency_conflict(node_package.name, test_result, package_spec=pkg_spec)
+
+        return cache_path, node_package
+
+    def _install_node_from_info(self, node_info: NodeInfo, no_test: bool = False) -> NodeInfo:
+        """Install a node given a pre-fetched NodeInfo object.
+
+        This bypasses the lookup/cache layer and directly installs the node
+        using the provided node info. Useful for update operations where we've
+        already fetched fresh data from the API.
+
+        Args:
+            node_info: Pre-fetched node information from API
+            no_test: Skip dependency resolution testing
+
+        Returns:
+            NodeInfo of the installed node
+
+        Raises:
+            CDEnvironmentError: If installation fails
+            CDNodeConflictError: If dependency conflicts detected
+        """
+        cache_path, node_package = self._prepare_node_installation(node_info, no_test=no_test)
 
         # === BEGIN TRANSACTIONAL SECTION ===
         # Snapshot state before any modifications for rollback
@@ -1619,7 +1629,8 @@ class NodeManager:
         self,
         identifier: str,
         confirmation_strategy: ConfirmationStrategy | None = None,
-        no_test: bool = False
+        no_test: bool = False,
+        target_version: str | None = None,
     ) -> UpdateResult:
         """Update a node based on its source type.
 
@@ -1627,6 +1638,8 @@ class NodeManager:
             identifier: Node identifier or name
             confirmation_strategy: Strategy for confirming updates (None = auto-confirm)
             no_test: Skip resolution testing (dev nodes only)
+            target_version: Optional exact registry version to install. Registry
+                nodes default to the registry's latest version when omitted.
 
         Returns:
             UpdateResult with details of what changed
@@ -1661,7 +1674,13 @@ class NodeManager:
         if node_info.source == 'development':
             return self._update_development_node(actual_identifier, node_info, no_test)
         elif node_info.source == 'registry':
-            return self._update_registry_node(actual_identifier, node_info, confirmation_strategy, no_test)
+            return self._update_registry_node(
+                actual_identifier,
+                node_info,
+                confirmation_strategy,
+                no_test,
+                target_version=target_version,
+            )
         elif node_info.source == 'git':
             return self._update_git_node(actual_identifier, node_info, confirmation_strategy, no_test)
         else:
@@ -1785,7 +1804,8 @@ class NodeManager:
         identifier: str,
         node_info: NodeInfo,
         confirmation_strategy: ConfirmationStrategy,
-        no_test: bool
+        no_test: bool,
+        target_version: str | None = None,
     ) -> UpdateResult:
         """Update registry node to latest version with atomic rollback on failure."""
         result = UpdateResult(node_name=node_info.name, source='registry')
@@ -1804,7 +1824,7 @@ class NodeManager:
             result.message = "No updates available (registry unavailable)"
             return result
 
-        latest_version = registry_node.latest_version.version
+        latest_version = target_version or registry_node.latest_version.version
         current_version = node_info.version or "unknown"
 
         if latest_version == current_version:
@@ -1815,6 +1835,24 @@ class NodeManager:
         if not confirmation_strategy.confirm_update(node_info.name, current_version, latest_version):
             result.message = "Update cancelled by user"
             return result
+
+        # Fetch complete install metadata and prepare the replacement before
+        # removing the old manifest entry. This is especially important for
+        # comfygit-manager because removing its dependency group can uninstall
+        # the running comfygit-core package from disk mid-update.
+        complete_version = self.node_lookup.registry_client.install_node(
+            node_info.registry_id,
+            latest_version
+        )
+
+        if not complete_version:
+            raise CDEnvironmentError(
+                f"Failed to get install metadata for '{node_info.name}' version {latest_version}"
+            )
+
+        registry_node.latest_version = complete_version
+        fresh_node_info = NodeInfo.from_registry_node(registry_node)
+        cache_path, node_package = self._prepare_node_installation(fresh_node_info, no_test=no_test)
 
         # === ATOMIC UPDATE WITH ROLLBACK ===
         # Preserve old node by disabling it instead of removing
@@ -1831,27 +1869,18 @@ class NodeManager:
                 shutil.move(node_path, disabled_path)
                 logger.debug(f"Disabled old version of '{node_info.name}'")
 
-            # STEP 2: Remove old node from tracking
+            # STEP 2: Remove old node from tracking. Do not sync here; the
+            # replacement package has already been prepared and will be synced
+            # in the same transaction after the new manifest entry is written.
             self.pyproject.nodes.remove(identifier)
+
+            # STEP 3: Install the prepared replacement and sync once.
+            shutil.copytree(cache_path, node_path, dirs_exist_ok=True)
+            logger.info(f"Installed node '{fresh_node_info.name}' to {node_path}")
+            self.add_node_package(node_package)
             self._sync_uv(quiet=True, all_groups=True, pytorch_manager=self.pytorch_manager)
 
-            # STEP 3: Get complete version data with downloadUrl from install endpoint
-            complete_version = self.node_lookup.registry_client.install_node(
-                node_info.registry_id,
-                latest_version
-            )
-
-            if complete_version:
-                # Replace incomplete version data with complete version
-                registry_node.latest_version = complete_version
-
-            # Create fresh node info from API response with complete data
-            fresh_node_info = NodeInfo.from_registry_node(registry_node)
-
-            # STEP 4: Install the new version
-            self._install_node_from_info(fresh_node_info, no_test=no_test)
-
-            # STEP 5: Success - delete old disabled version
+            # STEP 4: Success - delete old disabled version
             if disabled_path.exists():
                 rmtree(disabled_path)
                 logger.debug(f"Deleted old version of '{node_info.name}'")

--- a/packages/core/tests/integration/test_per_environment_manager.py
+++ b/packages/core/tests/integration/test_per_environment_manager.py
@@ -230,6 +230,103 @@ class TestUpdateManager:
         updated = test_env.pyproject.load()
         assert "headless" not in updated.get("tool", {}).get("comfygit", {})
 
+    def test_update_manager_prepares_replacement_before_removing_manifest(
+        self, test_env, tmp_path, monkeypatch
+    ):
+        """Manager updates must not uninstall core before staging the replacement."""
+        from comfygit_core.models.registry import RegistryNodeInfo, RegistryNodeVersion
+        from comfygit_core.models.shared import NodeInfo
+
+        current = NodeInfo(
+            name="comfygit-manager",
+            version="0.1.1",
+            source="registry",
+            registry_id="comfygit-manager",
+            repository="https://github.com/comfygit-ai/comfygit-manager",
+            download_url="https://cdn.comfy.org/akatz/comfygit-manager/0.1.1/node.zip",
+        )
+        group_name = test_env.pyproject.nodes.generate_group_name(current, "comfygit-manager")
+
+        config = test_env.pyproject.load()
+        config.setdefault("tool", {}).setdefault("comfygit", {}).setdefault("nodes", {})
+        config["tool"]["comfygit"]["nodes"]["comfygit-manager"] = {
+            "name": current.name,
+            "version": current.version,
+            "source": current.source,
+            "registry_id": current.registry_id,
+            "repository": current.repository,
+            "download_url": current.download_url,
+        }
+        config.setdefault("dependency-groups", {})[group_name] = ["comfygit-core==0.4.0"]
+        test_env.pyproject.save(config)
+
+        manager_path = test_env.comfyui_path / "custom_nodes" / "comfygit-manager"
+        manager_path.mkdir(parents=True)
+        (manager_path / "__init__.py").write_text("# manager 0.1.1")
+
+        cache_path = tmp_path / "cache" / "comfygit-manager-0.1.2"
+        cache_path.mkdir(parents=True)
+        (cache_path / "__init__.py").write_text("# manager 0.1.2")
+
+        registry_node = RegistryNodeInfo(
+            id="comfygit-manager",
+            name="comfygit-manager",
+            description="ComfyGit Manager",
+            repository="https://github.com/comfygit-ai/comfygit-manager",
+            latest_version=RegistryNodeVersion(
+                changelog="",
+                dependencies=[],
+                deprecated=False,
+                id="manager-v0.1.2",
+                version="0.1.2",
+                download_url="",
+            ),
+        )
+        install_version = RegistryNodeVersion(
+            changelog="",
+            dependencies=[],
+            deprecated=False,
+            id="manager-v0.1.2",
+            version="0.1.2",
+            download_url="https://cdn.comfy.org/akatz/comfygit-manager/0.1.2/node.zip",
+        )
+
+        def assert_manifest_still_present(_node_info):
+            nodes = test_env.pyproject.nodes.get_existing()
+            groups = test_env.pyproject.load().get("dependency-groups", {})
+            assert "comfygit-manager" in nodes
+            assert group_name in groups
+            return cache_path
+
+        monkeypatch.setattr(test_env.pytorch_manager, "ensure_backend", lambda *_args, **_kwargs: "cu121")
+        monkeypatch.setattr(
+            test_env.node_lookup,
+            "get_node",
+            lambda _identifier: NodeInfo(
+                name="comfygit-manager",
+                version="0.1.2",
+                source="registry",
+                registry_id="comfygit-manager",
+            ),
+        )
+        monkeypatch.setattr(test_env.node_lookup.registry_client, "get_node", lambda _node_id: registry_node)
+        monkeypatch.setattr(
+            test_env.node_lookup.registry_client,
+            "install_node",
+            lambda _node_id, _version: install_version,
+        )
+        monkeypatch.setattr(test_env.node_lookup, "download_to_cache", assert_manifest_still_present)
+        monkeypatch.setattr(test_env.node_lookup, "scan_requirements", lambda _path, **_kwargs: [])
+        monkeypatch.setattr(test_env.node_manager, "_sync_uv", lambda **_kwargs: None)
+
+        result = test_env.update_manager(version="0.1.2")
+
+        assert result.changed is True
+        assert result.old_version == "0.1.1"
+        assert result.new_version == "0.1.2"
+        assert test_env.pyproject.nodes.get_existing()["comfygit-manager"].version == "0.1.2"
+        assert (manager_path / "__init__.py").read_text() == "# manager 0.1.2"
+
 
 class TestEnvironmentCreation:
     """Tests for new environment creation with per-environment manager."""

--- a/packages/core/tests/integration/test_registry_node_update_empty_download_url.py
+++ b/packages/core/tests/integration/test_registry_node_update_empty_download_url.py
@@ -21,15 +21,12 @@ from comfygit_core.strategies.confirmation import AutoConfirmStrategy
 class TestRegistryNodeUpdateEmptyDownloadUrl:
     """Test registry node updates when API returns empty downloadUrl."""
 
-    def test_update_fails_when_registry_api_returns_empty_download_url(self, test_env):
-        """Test update fails when registry API returns empty downloadUrl.
+    def test_update_fails_clearly_when_install_metadata_is_unavailable(self, test_env):
+        """Test update fails clearly when complete install metadata is unavailable.
 
         Given: Node v1.8.0 is installed with valid downloadUrl
-        When: User updates and registry API returns v2.1.0 with empty downloadUrl
-        Then: Update should fail with clear error (current behavior - will be fixed)
-
-        This test documents the BUG - it expects failure.
-        After fix, this test will need to be updated to expect success.
+        When: User updates and the registry install endpoint has no v2.1.0 payload
+        Then: Update should fail before mutating the installed node.
         """
         # ARRANGE: Install initial version 1.8.0 with valid downloadUrl
         node_info_v1_8_0 = NodeInfo(
@@ -81,14 +78,10 @@ class TestRegistryNodeUpdateEmptyDownloadUrl:
 
             strategy = AutoConfirmStrategy()
 
-            # ACT & ASSERT: Update should fail because downloadUrl is empty
-            # The current implementation will try to fall back to git clone with version "2.1.0" as tag
-            # which will fail if the repo has no tags
             with pytest.raises(CDEnvironmentError) as exc_info:
                 test_env.node_manager.update_node("test-node", confirmation_strategy=strategy, no_test=True)
 
-            # Verify error message mentions the failure
-            assert "Failed to update node" in str(exc_info.value)
+            assert "Failed to get install metadata" in str(exc_info.value)
 
         # Verify old node is preserved after failed update (atomic rollback)
         nodes = test_env.pyproject.nodes.get_existing()

--- a/packages/studio/package-lock.json
+++ b/packages/studio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@comfygit/studio",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@comfygit/studio",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@radix-ui/react-select": "^2.2.6",

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@comfygit/studio",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "main": "./src/index.tsx",

--- a/uv.lock
+++ b/uv.lock
@@ -398,7 +398,7 @@ wheels = [
 
 [[package]]
 name = "comfygit"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "packages/cli" }
 dependencies = [
     { name = "aiohttp" },
@@ -417,7 +417,7 @@ requires-dist = [
 
 [[package]]
 name = "comfygit-core"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

- Bump ComfyGit core, CLI, and Studio release artifacts to 0.4.2.
- Fix registry-node updates so replacements are downloaded and validated before removing the existing manifest entry and syncing dependencies.
- Allow manager updates to target an explicit registry version, avoiding stale latest-version reads during self-update recovery.

## Root Cause

The previous registry update flow removed the existing node from `pyproject.toml` and synced before staging the replacement. For `comfygit-manager`, that dependency group owns the installed `comfygit-core` pin, so the update could uninstall the running core package mid-operation and fail on lazy imports like `comfygit_core.utils.download`.

## Validation

- `UV_PROJECT_ENVIRONMENT=/tmp/comfygit-release-venv uv run pytest packages/core/tests/integration/test_per_environment_manager.py::TestUpdateManager packages/core/tests/integration/test_registry_node_update_empty_download_url.py -q`
- `UV_PROJECT_ENVIRONMENT=/tmp/comfygit-release-venv uv run pytest packages/cli/tests/test_manager_commands.py -q`
- `UV_PROJECT_ENVIRONMENT=/tmp/comfygit-release-venv uv run ruff check packages/core/src/comfygit_core/managers/node_manager.py packages/core/src/comfygit_core/core/environment.py packages/core/tests/integration/test_per_environment_manager.py packages/core/tests/integration/test_registry_node_update_empty_download_url.py`
- `UV_PROJECT_ENVIRONMENT=/tmp/comfygit-release-venv make check-versions`
- `UV_PYTHON=$(command -v python3) make build-all`
